### PR TITLE
Case of one GPU 

### DIFF
--- a/util/misc.py
+++ b/util/misc.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if float(torchvision.__version__[:3]) < 0.7:
+if float(torchvision.__version__.split(".")[1]) < 7.0:
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 
@@ -454,7 +454,7 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
     This will eventually be supported natively by PyTorch, and this
     class can go away.
     """
-    if float(torchvision.__version__[:3]) < 0.7:
+    if float(torchvision.__version__.split(".")[1]) < 7.0:
         if input.numel() > 0:
             return torch.nn.functional.interpolate(
                 input, size, scale_factor, mode, align_corners


### PR DESCRIPTION
When running with just one GPU for the following line codes: 
`!python -m torch.distributed.launch \
--nproc_per_node=1 --use_env main.py \
--coco_path /content/coco/ \
--batch_size 1 \
--lr 2.5e-5 \
--epochs 150 \
--backbone_name small \
--pre_trained /content/deit_s_width_200.pth \
--eval_size 800 \
--init_pe_size 512 864 \
--mid_pe_size 512 864 \
--output_dir /content/Output/`

So the output says that it can not import `_new_empty_tensor` for surpassing this error I changed the verification of torchvision version on misc.py

Traceback (most recent call last):
  File "main.py", line 13, in <module>
    import datasets
  File "/content/YOLOS/datasets/__init__.py", line 5, in <module>
    from .coco import build as build_coco
  File "/content/YOLOS/datasets/coco.py", line 14, in <module>
    import datasets.transforms as T
  File "/content/YOLOS/datasets/transforms.py", line 13, in <module>
    from util.misc import interpolate
  File "/content/YOLOS/util/misc.py", line 22, in <module>
    from torchvision.ops import _new_empty_tensor
ImportError: cannot import name '_new_empty_tensor' from 'torchvision.ops' 